### PR TITLE
Add Flask web UI for live webcam emotion prediction, assets, and macOS helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,3 +224,35 @@ Overall, the developed FER model holds significant promise for various real-worl
 
 
 
+
+## User-Facing Web Application
+
+A simple web interface is now available using Flask + HTML/CSS/JS.
+
+### Features
+- Bold project header: **FACIAL EMOTION RECOGNITION**
+- Live webcam capture in browser
+- Emotion prediction using the trained `model.h5`
+- Feedback section with 5-star rating and text comments
+
+### Run locally
+```bash
+pip install flask pillow
+python web_app.py
+```
+Then open: `http://localhost:5000`
+
+
+### macOS (Apple Silicon M1/M2) quick start
+Use the helper script to set up a virtual environment, install dependencies, and run the app:
+
+```bash
+chmod +x run_macos_m2.sh
+./run_macos_m2.sh
+```
+
+Then open `http://localhost:5000` in your browser.
+
+If camera access is blocked on macOS, allow it in:
+- **System Settings → Privacy & Security → Camera**
+- enable camera permission for your browser (Chrome/Safari/Edge)

--- a/requirements (1).txt
+++ b/requirements (1).txt
@@ -51,3 +51,4 @@ werkzeug==3.0.2
 wheel==0.41.2
 wrapt==1.16.0
 zipp==3.17.0
+flask==3.0.3

--- a/run_macos_m2.sh
+++ b/run_macos_m2.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+if ! command -v python3.10 >/dev/null 2>&1; then
+  echo "[INFO] python3.10 not found. Install with: brew install python@3.10"
+  exit 1
+fi
+
+if [ ! -d ".venv" ]; then
+  echo "[INFO] Creating virtual environment (.venv) with python3.10"
+  python3.10 -m venv .venv
+fi
+
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+echo "[INFO] Upgrading pip tooling"
+pip install --upgrade pip setuptools wheel
+
+echo "[INFO] Installing project requirements"
+pip install -r "requirements (1).txt"
+
+echo "[INFO] Installing web app runtime dependencies"
+pip install flask pillow
+
+echo "[INFO] Installing desktop OpenCV for local development"
+pip install opencv-python
+
+echo "[INFO] Verifying key imports"
+python - <<'PY'
+import cv2
+import flask
+import PIL
+print('cv2:', cv2.__version__)
+print('flask:', flask.__version__)
+print('Pillow:', PIL.__version__)
+PY
+
+echo "[INFO] Starting app at http://localhost:5000"
+python web_app.py

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,109 @@
+:root {
+  --bg: #0f172a;
+  --card: #1e293b;
+  --text: #e2e8f0;
+  --accent: #38bdf8;
+  --muted: #94a3b8;
+  --star: #fbbf24;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", Arial, sans-serif;
+  background: linear-gradient(160deg, #020617, #0f172a 55%, #1e293b);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.container {
+  width: min(900px, 92%);
+  margin: 2rem auto;
+}
+
+h1 {
+  text-align: center;
+  font-weight: 900;
+  letter-spacing: 1.5px;
+  margin-bottom: 0.8rem;
+}
+
+.intro {
+  text-align: center;
+  color: var(--muted);
+  line-height: 1.6;
+  margin: 0 auto 1.4rem;
+  max-width: 760px;
+}
+
+.camera-card,
+.feedback-card {
+  background: rgba(30, 41, 59, 0.85);
+  border: 1px solid #334155;
+  border-radius: 14px;
+  padding: 1rem;
+  margin-top: 1rem;
+}
+
+#video {
+  width: 100%;
+  border-radius: 10px;
+  border: 2px solid #334155;
+  background: #000;
+  min-height: 320px;
+}
+
+.result-row {
+  margin-top: 0.8rem;
+  display: flex;
+  gap: 0.6rem;
+}
+
+button {
+  background: var(--accent);
+  color: #082f49;
+  border: none;
+  border-radius: 8px;
+  padding: 0.6rem 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+#status { color: var(--muted); }
+
+.emotion-text {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+h2 { margin-top: 0; }
+
+.stars span {
+  font-size: 2rem;
+  cursor: pointer;
+  color: #64748b;
+}
+
+.stars span.active {
+  color: var(--star);
+}
+
+textarea {
+  width: 100%;
+  margin-top: 0.7rem;
+  border-radius: 8px;
+  border: 1px solid #334155;
+  background: #0f172a;
+  color: var(--text);
+  padding: 0.6rem;
+}
+
+#feedbackMsg {
+  color: #86efac;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Facial Emotion Recognition</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
+</head>
+<body>
+  <main class="container">
+    <h1>FACIAL EMOTION RECOGNITION</h1>
+    <p class="intro">
+      This project captures your facial expression in real time and classifies your emotion using
+      a trained deep learning model. The app combines <strong>Python</strong>, <strong>Flask</strong>,
+      <strong>OpenCV</strong>, <strong>TensorFlow/Keras</strong>, and browser webcam APIs to deliver a
+      simple user-facing FER experience.
+    </p>
+
+    <section class="camera-card">
+      <video id="video" autoplay playsinline></video>
+      <canvas id="canvas" hidden></canvas>
+      <div class="result-row">
+        <button id="startBtn">Start Camera</button>
+        <button id="analyzeBtn" disabled>Analyze Emotion</button>
+      </div>
+      <p id="status">Click <em>Start Camera</em> to begin.</p>
+      <p id="emotion" class="emotion-text"></p>
+    </section>
+
+    <section class="feedback-card">
+      <h2>Rate Your Experience</h2>
+      <div class="stars" id="stars" aria-label="5 star rating">
+        <span data-value="1">★</span>
+        <span data-value="2">★</span>
+        <span data-value="3">★</span>
+        <span data-value="4">★</span>
+        <span data-value="5">★</span>
+      </div>
+      <textarea id="comment" rows="4" placeholder="Share your feedback..."></textarea>
+      <button id="submitFeedback">Submit Feedback</button>
+      <p id="feedbackMsg"></p>
+    </section>
+  </main>
+
+  <script>
+    const video = document.getElementById('video');
+    const canvas = document.getElementById('canvas');
+    const startBtn = document.getElementById('startBtn');
+    const analyzeBtn = document.getElementById('analyzeBtn');
+    const statusEl = document.getElementById('status');
+    const emotionEl = document.getElementById('emotion');
+
+    let stream;
+    let selectedRating = 0;
+
+    startBtn.addEventListener('click', async () => {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
+        video.srcObject = stream;
+        analyzeBtn.disabled = false;
+        statusEl.textContent = 'Camera started. Click Analyze Emotion.';
+      } catch (err) {
+        statusEl.textContent = 'Unable to access camera. Please allow webcam permissions.';
+      }
+    });
+
+    analyzeBtn.addEventListener('click', async () => {
+      if (!stream) return;
+
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+      const imageData = canvas.toDataURL('image/jpeg');
+      statusEl.textContent = 'Analyzing...';
+
+      try {
+        const response = await fetch('/predict', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ image: imageData })
+        });
+
+        const result = await response.json();
+        if (!response.ok) {
+          emotionEl.textContent = result.error || 'Prediction failed.';
+          statusEl.textContent = 'Try again.';
+          return;
+        }
+
+        const confidence = result.confidence !== undefined ? ` (${Math.round(result.confidence * 100)}% confidence)` : '';
+        emotionEl.textContent = `Detected Emotion: ${result.emotion}${confidence}`;
+        statusEl.textContent = 'Analysis complete.';
+      } catch (err) {
+        emotionEl.textContent = 'Network error while predicting emotion.';
+        statusEl.textContent = 'Please retry.';
+      }
+    });
+
+    const stars = document.querySelectorAll('#stars span');
+    stars.forEach(star => {
+      star.addEventListener('click', () => {
+        selectedRating = Number(star.dataset.value);
+        stars.forEach(s => s.classList.toggle('active', Number(s.dataset.value) <= selectedRating));
+      });
+    });
+
+    document.getElementById('submitFeedback').addEventListener('click', () => {
+      const comment = document.getElementById('comment').value.trim();
+      const msg = document.getElementById('feedbackMsg');
+
+      if (!selectedRating) {
+        msg.textContent = 'Please provide a star rating before submitting.';
+        return;
+      }
+
+      msg.textContent = `Thanks for your feedback! Rating: ${selectedRating}/5${comment ? ' | Comment received.' : ''}`;
+      document.getElementById('comment').value = '';
+    });
+  </script>
+</body>
+</html>

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import base64
+from io import BytesIO
+
+import cv2
+import numpy as np
+from flask import Flask, jsonify, render_template, request
+from keras.models import load_model
+from keras.preprocessing.image import img_to_array
+from PIL import Image
+
+app = Flask(__name__)
+
+# Load model assets once at startup
+face_classifier = cv2.CascadeClassifier(cv2.data.haarcascades + "haarcascade_frontalface_default.xml")
+classifier = load_model("model.h5")
+emotion_labels = ["Angry", "Disgust", "Fear", "Happy", "Neutral", "Sad", "Surprise"]
+
+
+@app.get("/")
+def index() -> str:
+    return render_template("index.html")
+
+
+@app.post("/predict")
+def predict():
+    payload = request.get_json(silent=True) or {}
+    image_data = payload.get("image", "")
+
+    if not image_data.startswith("data:image"):
+        return jsonify({"error": "Invalid image payload."}), 400
+
+    try:
+        image_b64 = image_data.split(",", maxsplit=1)[1]
+        image_bytes = base64.b64decode(image_b64)
+        pil_image = Image.open(BytesIO(image_bytes)).convert("RGB")
+        frame = cv2.cvtColor(np.array(pil_image), cv2.COLOR_RGB2BGR)
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        faces = face_classifier.detectMultiScale(gray, scaleFactor=1.1, minNeighbors=5)
+
+        if len(faces) == 0:
+            return jsonify({"emotion": "No face detected"})
+
+        largest_face = max(faces, key=lambda b: b[2] * b[3])
+        x, y, w, h = largest_face
+        roi_gray = gray[y : y + h, x : x + w]
+        roi_gray = cv2.resize(roi_gray, (48, 48), interpolation=cv2.INTER_AREA)
+
+        roi = roi_gray.astype("float32") / 255.0
+        roi = img_to_array(roi)
+        roi = np.expand_dims(roi, axis=0)
+
+        prediction = classifier.predict(roi, verbose=0)[0]
+        label = emotion_labels[int(prediction.argmax())]
+        confidence = float(np.max(prediction))
+
+        return jsonify({"emotion": label, "confidence": round(confidence, 3)})
+    except Exception as exc:  # defensive for malformed camera payloads
+        return jsonify({"error": f"Prediction failed: {exc}"}), 500
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=False)


### PR DESCRIPTION
### Motivation

- Provide a simple user-facing interface to run the trained Facial Emotion Recognition model in-browser via webcam and collect feedback. 
- Make it easy to run locally (especially on macOS M1/M2) with a helper script and documented quick start steps.

### Description

- Add a Flask app `web_app.py` that loads `model.h5` and a Haar cascade at startup and exposes `GET /` to serve a UI and `POST /predict` to accept a base64 image and return `{"emotion", "confidence"}` or error responses. 
- Add a browser UI in `templates/index.html` with live webcam capture, an analyze flow that posts camera frames to `/predict`, and a feedback panel with a 5-star rating and comments. 
- Add styling in `static/styles.css` and update `README.md` with usage instructions and macOS quick start information, plus add `flask==3.0.3` to `requirements (1).txt`. 
- Add `run_macos_m2.sh` to create a Python 3.10 virtualenv, install dependencies, verify key imports (`cv2`, `flask`, `PIL`), install OpenCV for development, and start the app.

### Testing

- No automated test suite was executed as part of this change. 
- A local helper script `run_macos_m2.sh` is provided which, when executed, performs an import verification snippet that prints versions for `cv2`, `flask`, and `Pillow` to help validate the runtime environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0d7e2f850832fa5aff88c54635215)